### PR TITLE
[Chore] Add platforms spec in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
     name: "Refresh",
+    platforms: [
+       .macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)
+    ],
     products: [
         .library(
             name: "Refresh",


### PR DESCRIPTION
Add platforms spec into `Package.swift` to prevent SwiftUI errors when archiving